### PR TITLE
Added smartCostLimit MQTT Topics

### DIFF
--- a/installation/evcc-mqtt-integration/entities-dashboard/evcc-mqtt-entities.yaml
+++ b/installation/evcc-mqtt-integration/entities-dashboard/evcc-mqtt-entities.yaml
@@ -37,6 +37,7 @@ views:
           - entity: sensor.evcc_lp_1_session_price
           - entity: sensor.evcc_lp_1_session_price_per_kwh
           - entity: binary_sensor.evcc_lp_1_smart_cost_active
+          - entity: number.evcc_lp_1_smart_cost_limit
           - entity: sensor.evcc_lp_1_vehicle_name
           - entity: sensor.evcc_lp_1_vehicle_soc
         title: Loadpoint 1
@@ -61,6 +62,7 @@ views:
           - entity: sensor.evcc_lp_2_session_price
           - entity: sensor.evcc_lp_2_session_price_per_kwh
           - entity: binary_sensor.evcc_lp_2_smart_cost_active
+          - entity: number.evcc_lp_2_smart_cost_limit
           - entity: sensor.evcc_lp_2_vehicle_name
           - entity: sensor.evcc_lp_2_vehicle_soc
         title: Loadpoint 2
@@ -84,6 +86,8 @@ views:
         entities:
           - entity: input_number.helper_evcc_lp_1_vehicle_min_soc
           - entity: input_text.helper_evcc_lp_1_vehicle_title
+          - entity: sensor.helper_lp1_summary_text
           - entity: input_number.helper_evcc_lp_2_vehicle_min_soc
           - entity: input_text.helper_evcc_lp_2_vehicle_title
+          - entity: sensor.helper_lp2_summary_text
         title: Helpers

--- a/installation/evcc-mqtt-integration/evcc_loadpoint1_mqtt.yaml
+++ b/installation/evcc-mqtt-integration/evcc_loadpoint1_mqtt.yaml
@@ -202,3 +202,14 @@ mqtt:
       step: 5
       unit_of_measurement: "%"
 
+    - name: evcc_lp_1_smart_cost_limit
+      unique_id: uniqueid__evcc_lp_1_smart_cost_limit
+      icon: mdi:label-percent-outline
+      state_topic: "evcc/loadpoints/1/smartCostLimit"
+      command_topic: "evcc/loadpoints/1/smartCostLimit/set"
+      availability_topic: "evcc/status"
+      min: -0.05
+      max: 0.445
+      step: 0.005
+      unit_of_measurement: "€"
+

--- a/installation/evcc-mqtt-integration/evcc_loadpoint2_mqtt.yaml
+++ b/installation/evcc-mqtt-integration/evcc_loadpoint2_mqtt.yaml
@@ -202,3 +202,14 @@ mqtt:
       step: 5
       unit_of_measurement: "%"
 
+    - name: evcc_lp_2_smart_cost_limit
+      unique_id: uniqueid__evcc_lp_2_smart_cost_limit
+      icon: mdi:label-percent-outline
+      state_topic: "evcc/loadpoints/2/smartCostLimit"
+      command_topic: "evcc/loadpoints/2/smartCostLimit/set"
+      availability_topic: "evcc/status"
+      min: -0.05
+      max: 0.445
+      step: 0.005
+      unit_of_measurement: "€"
+


### PR DESCRIPTION
Added smart_cost_limit MQTT entity for loadpoints so that we can change the smart cost limit through automations.

Entities:
- evcc_lp_1_smart_cost_limit
- evcc_lp_2_smart_cost_limit