### PR TITLE
Tibber: Heimspeicher: Nächtliches speicher sparen

### DIFF
--- a/use-cases/tibber/naechtliches-speicher-sparen/README.md
+++ b/use-cases/tibber/naechtliches-speicher-sparen/README.md
@@ -1,0 +1,12 @@
+# Tibber: Nächtliches Speicher sparen
+
+Warum sollte sich der Speicher nachts in den günstigen Stunden ganz entleeren und morgens, wenn es wieder teurer wird muss man dann den teuren Strom kaufen?
+
+Diese Automatisierung verhindert nach 0:00 Uhr die weitere Speicherentladung, wenn der Speicher unter 35% fällt, und aktiviert ihn morgens wieder rechtzeitig zu den teuren Stunden, so dass man möglichst die Zeit bis die Sonne scheint wieder überbrücken kann.
+
+Die Entladeschwelle von 35% ist an die jeweilige Speicherkapazität und den individuell zu erwartenden morgendlichen Stromverbrauch anzupassen.
+
+## Abhängigkeiten
+
+- [Heimspeicher: Entladung Verhindern](../../../shared/heimspeicher/heimspeicher-entladung-deaktivieren/)
+

--- a/use-cases/tibber/naechtliches-speicher-sparen/naechtliches-speicher-sparen-morgens-beenden.yaml
+++ b/use-cases/tibber/naechtliches-speicher-sparen/naechtliches-speicher-sparen-morgens-beenden.yaml
@@ -1,0 +1,34 @@
+alias: "Heimspeicher: Nächtliches Speichersparen aktivieren"
+description: ""
+triggers:
+  - trigger: numeric_state
+    entity_id:
+      - sensor.sofar_battery_capacity_total
+    below: 35
+  - trigger: time
+    at: "00:00:00"
+conditions:
+  - alias: Zwischen 0:00 und 6:30
+    condition: time
+    after: "00:00:00"
+    before: "06:00:00"
+    weekday:
+      - mon
+      - tue
+      - wed
+      - thu
+      - fri
+      - sat
+      - sun
+  - condition: numeric_state
+    entity_id: sensor.sofar_battery_capacity_total
+    below: 35
+actions:
+  - alias: Speicherentladung deaktiviert
+    action: input_boolean.turn_on
+    target:
+      entity_id:
+        - input_boolean.helper_home_battery_discharge_disabled
+        - input_boolean.helper_nightly_battery_saver
+    data: {}
+mode: single

--- a/use-cases/tibber/naechtliches-speicher-sparen/sofar-solar-HYD-x-KTL/naechtliches-speicher-sparen-deaktivieren.yaml
+++ b/use-cases/tibber/naechtliches-speicher-sparen/sofar-solar-HYD-x-KTL/naechtliches-speicher-sparen-deaktivieren.yaml
@@ -1,0 +1,23 @@
+alias: "Heimspeicher: Nächtliches Speichersparen morgens beenden"
+description: ""
+triggers:
+  - alias: Morgens um 6:30
+    trigger: time
+    at: "06:00:00"
+conditions:
+  - condition: state
+    entity_id: input_boolean.helper_nightly_battery_saver
+    state: "on"
+    alias: Wenn nächtliches Speichersparen aktiviert wurde.
+actions:
+  - action: input_boolean.turn_off
+    target:
+      entity_id: input_boolean.helper_nightly_battery_saver
+    data: {}
+    alias: Flag löschen
+  - action: input_boolean.turn_off
+    data: {}
+    target:
+      entity_id: input_boolean.helper_home_battery_discharge_disabled
+    alias: Speicher aktivieren
+mode: single


### PR DESCRIPTION
Scripte um das sparen von Speicherkapazität nachts zu erlauben um die restliche Kapazität morgens zu teureren Stunden nutzen zu können.