### PR TITLE
EVCC Automationen

### DIFF
--- a/installation/evcc-mqtt-integration/entities-dashboard/evcc-mqtt-entities.yaml
+++ b/installation/evcc-mqtt-integration/entities-dashboard/evcc-mqtt-entities.yaml
@@ -8,6 +8,7 @@ views:
           - entity: sensor.evcc_site_battery_discharge_control
           - entity: sensor.evcc_site_battery_mode
           - entity: sensor.evcc_site_battery_grid_charge_active
+          - entity: number.evcc_site_battery_grid_charge_limit
           - entity: number.evcc_site_buffer_soc
           - entity: sensor.evcc_site_grid_power
           - entity: sensor.evcc_site_home_power

--- a/installation/evcc-mqtt-integration/evcc_site_mqtt.yaml
+++ b/installation/evcc-mqtt-integration/evcc_site_mqtt.yaml
@@ -131,3 +131,14 @@ mqtt:
       min: -5000
       max: +5000
       unit_of_measurement: "W"
+
+    - name: evcc_site_battery_grid_charge_limit
+      unique_id: uniqueid__battery_grid_charge_limit
+      icon: mdi:currency-eur
+      state_topic: "evcc/site/batteryGridChargeLimit"
+      command_topic: "evcc/site/batteryGridChargeLimit/set"
+      availability_topic: "evcc/status"
+      unit_of_measurement: "€"
+      min: -0.05
+      max: 0.445
+      step: 0.005

--- a/use-cases/evcc/reset-battery-charge-limit/README.md
+++ b/use-cases/evcc/reset-battery-charge-limit/README.md
@@ -1,0 +1,13 @@
+# EVCC: Morgendlicher reset von Battery Grid Charge Limit
+
+EVCC erlaubt den Speicher nachts zu einem bestimmten Preis für den nächsten Tag aufzuladen. Das Problem jedoch: Nachdem man einen Preis eingestellt hat sollte man nicht vergessen diesen Preis wieder zurückzusetzen, denn sonst lädt die Batterie beim nächsten Unterschreiten des Preises Tage später wieder los - obwohl danach keine hohe Preisphase kommt.
+
+Hier hilft diese Automation, die jeden Morgen um 9:00 Uhr den Preis wieder auf 0 zurücksetzt.
+
+## Abhängigkeiten
+
+- [EVCC MQTT Integration](../../../installation/evcc-mqtt-integration/)
+
+## Automatisierungen
+
+Automatisierung mit Hilfe der YAML Datei erstellen.

--- a/use-cases/evcc/reset-battery-charge-limit/reset-battery-charge-limit.yaml
+++ b/use-cases/evcc/reset-battery-charge-limit/reset-battery-charge-limit.yaml
@@ -1,0 +1,14 @@
+alias: "EVCC: Morgendlicher reset von Battery Grid Charge Limit"
+description: ""
+triggers:
+  - trigger: time
+    at: "09:00:00"
+conditions: []
+actions:
+  - action: number.set_value
+    metadata: {}
+    data:
+      value: "0"
+    target:
+      entity_id: number.evcc_site_battery_grid_charge_limit
+mode: single

--- a/use-cases/evcc/reset-loadpoint/README.md
+++ b/use-cases/evcc/reset-loadpoint/README.md
@@ -1,0 +1,14 @@
+# EVCC: Reset Loadpoint
+
+Manche Standardwerte setzt EVCC schon von sich aus. Andere will man selbst wieder setzen. Hier werden gewünschte Standardwerte nach dem Ausstecken des Fahrzeugs an dem betreffenden Loadpoint gesetzt:
+
+- Lademodus auf PV
+- Preislimit für das Laden auf 20ct.
+
+## Abhängigkeiten
+
+- [EVCC MQTT Integration](../../../installation/evcc-mqtt-integration/)
+
+## Automatisierungen
+
+Automatisierung mit Hilfe der YAML Datei erstellen.

--- a/use-cases/evcc/reset-loadpoint/reset-loadpoint-1.yaml
+++ b/use-cases/evcc/reset-loadpoint/reset-loadpoint-1.yaml
@@ -1,0 +1,23 @@
+alias: "EVCC: LP1: Reset nach ausstecken"
+description: ""
+triggers:
+  - entity_id:
+      - binary_sensor.evcc_lp_1_connected
+    to: "off"
+    from: "on"
+    trigger: state
+conditions: []
+actions:
+  - metadata: {}
+    data:
+      value: "0.20"
+    target:
+      entity_id: number.evcc_lp_1_smart_cost_limit
+    action: number.set_value
+  - action: select.select_option
+    metadata: {}
+    data:
+      option: pv
+    target:
+      entity_id: select.evcc_lp_1_mode
+mode: single

--- a/use-cases/evcc/reset-loadpoint/reset-loadpoint-2.yaml
+++ b/use-cases/evcc/reset-loadpoint/reset-loadpoint-2.yaml
@@ -1,0 +1,23 @@
+alias: "EVCC: LP2: Reset nach ausstecken"
+description: ""
+triggers:
+  - entity_id:
+      - binary_sensor.evcc_lp_2_connected
+    to: "off"
+    from: "on"
+    trigger: state
+conditions: []
+actions:
+  - metadata: {}
+    data:
+      value: "0.20"
+    target:
+      entity_id: number.evcc_lp_2_smart_cost_limit
+    action: number.set_value
+  - action: select.select_option
+    metadata: {}
+    data:
+      option: pv
+    target:
+      entity_id: select.evcc_lp_2_mode
+mode: single


### PR DESCRIPTION
- Morgendlicher Reset des Preislimits für das Laden der Hausbatterie.
- Reset der Loadpoints nach dem Ausstecken.