### PR TITLE
Heimspeichersteuerung: EVCC Speicher Kontrolle

### DIFF
--- a/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/README.md
+++ b/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/README.md
@@ -1,4 +1,6 @@
 > [!NOTE]  
+> 2025-05-14: Berücksichtigung der EVCC Speichersteuerung.
+> 
 > 2025-05-05: Da sich bei mir der Passive Mode immer wieder geändert hat - warum auch immer, habe ich nun eine Automatisierung geschrieben, die die Werte überwacht und sicherstellt, dass die aktuellen Werte immer zur aktuellen Einstellung des Helfers passen. Dies zog weitreichende Änderungen nach sich. Bitte alle Skripte und Automatisierungen aktualisieren.
 
 # Heimspeicher steuern (Sofar Solar HYD x KTL)

--- a/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/automatisierungen/modus-änderung.yaml
+++ b/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/automatisierungen/modus-änderung.yaml
@@ -8,10 +8,26 @@ triggers:
       hours: 0
       minutes: 0
       seconds: 3
-conditions: []
+  - trigger: state
+    entity_id:
+      - sensor.evcc_site_battery_discharge_control
+    to: "false"
+  - trigger: state
+    entity_id:
+      - sensor.evcc_site_battery_grid_charge_active
+    to: "false"
+conditions:
+  - condition: and
+    conditions:
+      - condition: state
+        entity_id: sensor.evcc_site_battery_discharge_control
+        state: "false"
+      - condition: state
+        entity_id: sensor.evcc_site_battery_grid_charge_active
+        state: "false"
+    alias: EVCC hat derzeit keine Kontrolle über die Batterieladung
 actions:
   - action: script.heimspeicher_modus_setzen
     metadata: {}
     data: {}
 mode: single
-

--- a/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/automatisierungen/werte-überwachen-neu-setzen.yaml
+++ b/use-cases/heimspeicher/heimspeicher-steuern/sofar-solar-HYD-x-KTL/automatisierungen/werte-überwachen-neu-setzen.yaml
@@ -33,6 +33,16 @@ conditions:
   - condition: state
     entity_id: input_boolean.helper_battery_updating_passive_mode
     state: "off"
+    alias: Die Werte werden gerade durch das Script geändert.
+  - condition: and
+    conditions:
+      - condition: state
+        entity_id: sensor.evcc_site_battery_discharge_control
+        state: "false"
+      - condition: state
+        entity_id: sensor.evcc_site_battery_grid_charge_active
+        state: "false"
+    alias: EVCC hat derzeit keine Kontrolle über die Batterieladung
 actions:
   - variables:
       old_desired_grid_power: "{{ states('number.sofar_passive_mode_grid_power') }}"
@@ -47,7 +57,7 @@ actions:
       - condition: template
         value_template: "{{ return_values.values_updated == true }}"
     then:
-      - action: notify.mobile_app_<companion_app_device_name>
+      - action: notify.mobile_app_pixel_8
         metadata: {}
         data:
           title: Passive Mode Werte wurden unerwartet geändert.
@@ -65,11 +75,12 @@ actions:
           data:
             notification_icon: mdi:home-battery
             color: red
+    alias: Benachrichtige, wenn sich die Leistungswerte geändert haben.
   - if:
       - condition: template
         value_template: "{{ return_values.energy_storage_mode_changed == true }}"
     then:
-      - action: notify.mobile_app_<companion_app_device_name>
+      - action: notify.mobile_app_pixel_8
         metadata: {}
         data:
           title: Energy Storage Mode wurde unerwartet geändert.
@@ -81,4 +92,5 @@ actions:
           data:
             notification_icon: mdi:home-battery
             color: red
+    alias: Benachrichtige, wenn sich der Storage Mode geändert hat.
 mode: single


### PR DESCRIPTION
Berücksichtigung, wenn EVCC den Speicher kontrolliert, damit hier nicht dazwischengefunkt wird.