### PR TITLE
Update evcc_loadpoint2_mqtt.yaml

### DIFF
--- a/installation/evcc-mqtt-integration/evcc_loadpoint2_mqtt.yaml
+++ b/installation/evcc-mqtt-integration/evcc_loadpoint2_mqtt.yaml
@@ -119,7 +119,6 @@ mqtt:
 
     - name: evcc_lp_2_session_price
       unique_id: uniqueid__evcc_lp_2_session_price
-      icon: mdi:home-lightning-bolt-outline
       state_topic: "evcc/loadpoints/2/sessionPrice"
       state_class: total
       icon: mdi:currency-eur
@@ -128,7 +127,6 @@ mqtt:
 
     - name: evcc_lp_2_session_price_per_kwh
       unique_id: uniqueid__evcc_lp_2_session_price_per_kwh
-      icon: mdi:home-lightning-bolt-outline
       state_topic: "evcc/loadpoints/2/sessionPricePerKWh"
       state_class: total
       icon: mdi:currency-eur


### PR DESCRIPTION
The icon was set twice, resulting in a syntax error. loadpoint1 is also affected and has been modified.